### PR TITLE
Replace dashes in paragraphs with commas or new lines

### DIFF
--- a/code-of-care.html
+++ b/code-of-care.html
@@ -7,7 +7,7 @@
   <meta name="keywords" content="motherhood, support, postpartum, new moms, mom help, mama circle, community, parenting, emotional care" />
   <meta name="author" content="Mama Circle" />
   <meta property="og:title" content="Mama Circle 💞" />
-  <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas — no sign-ups, no judgment." />
+    <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas, no sign-ups, no judgment." />
   <meta property="og:url" content="https://mamacircle.me" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://mamacircle.me/assets/mandala-circle.png" />
@@ -51,7 +51,7 @@
       <ul>
         <li><strong>Respond gently.</strong> New mothers may be feeling tender, overwhelmed, or unsure.</li>
         <li><strong>Hold space.</strong> Sometimes the most powerful thing you can do is simply witness.</li>
-        <li><strong>Respect silence.</strong> Nobody owes a response — your presence alone may be enough.</li>
+          <li><strong>Respect silence.</strong> Nobody owes a response, your presence alone may be enough.</li>
       </ul>
   
       <h2>Honor boundaries</h2>
@@ -65,12 +65,12 @@
       <ul>
         <li><strong>Report misuse.</strong> If you see the hashtag being used in harmful ways, let us know by sending an email to <code>hello@mamacircle.me</code>.</li>
         <li><strong>Trust your gut.</strong> It’s okay to ignore or block anyone who feels unsafe to you.</li>
-        <li><strong>Prioritize emotional safety</strong> — yours and theirs.</li>
+          <li><strong>Prioritize emotional safety</strong>, yours and theirs.</li>
       </ul>
   
       <h2>Be inclusive</h2>
       <ul>
-        <li><strong>Everyone deserves kindness</strong> — no matter their background, parenting style, or identity.</li>
+          <li><strong>Everyone deserves kindness</strong>, no matter their background, parenting style, or identity.</li>
         <li><strong>Use affirming language.</strong> Avoid assumptions about someone's journey or story.</li>
       </ul>
   
@@ -80,7 +80,7 @@
       <hr />
   
       <p>
-        The Circle lives in the quiet care we show one another — in the small moments of connection.  
+          The Circle lives in the quiet care we show one another, in the small moments of connection.
         <strong>Thank you for being part of this. 💞</strong>
       </p>
     </section>

--- a/index-pt.html
+++ b/index-pt.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Mama Circle 💞 é um espaço de apoio entre mães. Sem inscrições, sem pressão — apenas presença gentil umas pelas outras.">
+    <meta name="description" content="Mama Circle 💞 é um espaço de apoio entre mães. Sem inscrições, sem pressão, apenas presença gentil umas pelas outras.">
   <meta name="keywords" content="maternidade, apoio, pós-parto, novas mães, ajuda para mães, mama circle, comunidade, parentalidade, cuidado emocional" />
   <meta name="author" content="Mama Circle" />
   <meta property="og:title" content="Mama Circle 💞" />
-  <meta property="og:description" content="Um lugar gentil para pousar na maternidade. Mães apoiando mães — sem julgamentos." />
+    <meta property="og:description" content="Um lugar gentil para pousar na maternidade. Mães apoiando mães, sem julgamentos." />
   <meta property="og:url" content="https://mamacircle.me" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://mamacircle.me/assets/mandala-circle.png" />
@@ -53,13 +53,14 @@
   <main id="top" role="main" class="wrapper">
     <section class="header">
       <img class="logo" src="assets/mandala-circle.png" alt="Logo Mama Circle - Mandala"/>
-      <h1>Mama Circle <span class="strapline"> — um lugar gentil para pousar na maternidade</span></h1>
+      <h1>Mama Circle</h1>
+      <p class="strapline">um lugar gentil para pousar na maternidade</p>
 
       <div class="intro">
-        <p>Se você se tornou mãe recentemente e está se sentindo sobrecarregada, emocional, ou só precisando de uma palavra gentil — esse espaço é para você.</p>
-        <p>O Mama Circle não é um grupo nem um app. É um sinal silencioso — uma forma simples de mães se encontrarem através da hashtag <span class="hashtag">#mamacircle 💞</span>.</p>
-        <p>Talvez você encontre alguém que diga:<br />
-        <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span> — você pode contar comigo, se se sentir segura.</em><br />
+          <p>Se você se tornou mãe recentemente e está se sentindo sobrecarregada, emocional, ou só precisando de uma palavra gentil, esse espaço é para você.</p>
+          <p>O Mama Circle não é um grupo nem um app. É um sinal silencioso, uma forma simples de mães se encontrarem através da hashtag <span class="hashtag">#mamacircle 💞</span>.</p>
+          <p>Talvez você encontre alguém que diga:<br />
+          <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span>, você pode contar comigo, se se sentir segura.</em><br />
         <strong>E ela diz com intenção.</strong></p>
       </div>
     </section>
@@ -67,12 +68,12 @@
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">
       <h2 id="manifesto-heading">O Manifesto do Mama Circle</h2>
       <ul class="blockquote">
-        <li>Quando você estiver cansada — <em>oferecemos compreensão.</em></li>
-        <li>Quando estiver sobrecarregada — <em>oferecemos calma.</em></li>
-        <li>Quando estiver insegura — <em>oferecemos histórias.</em></li>
-        <li>Quando estiver sozinha — <em>oferecemos conexão.</em></li>
-        <li>Quando estiver perdida — <em>oferecemos umas às outras.</em></li>
-        <li>E se estivermos por perto — <em>levamos chá, seguramos seu bebê, limpamos sua cozinha ou damos um abraço.</em></li>
+          <li>Quando você estiver cansada, <em>oferecemos compreensão.</em></li>
+          <li>Quando estiver sobrecarregada, <em>oferecemos calma.</em></li>
+          <li>Quando estiver insegura, <em>oferecemos histórias.</em></li>
+          <li>Quando estiver sozinha, <em>oferecemos conexão.</em></li>
+          <li>Quando estiver perdida, <em>oferecemos umas às outras.</em></li>
+          <li>E se estivermos por perto, <em>levamos chá, seguramos seu bebê, limpamos sua cozinha ou damos um abraço.</em></li>
       </ul>
 
       <hr class="divider" />
@@ -85,7 +86,7 @@
         <li>Comunidade <strong>acima de</strong> competição</li>
       </ul>
 
-      <p class="note">Esses são os valores do Mama Circle — não é sobre perfeição, mas sobre se fazer presente.</p>
+        <p class="note">Esses são os valores do Mama Circle, não é sobre perfeição, mas sobre se fazer presente.</p>
     </section>
 
     <section id="how-it-works">
@@ -118,19 +119,19 @@
         <p>Se você já é mãe e quer estar disponível com intenção para novas mães, você pode:</p>
         <ul>
           <li>Dizer o sinal do círculo ao encontrar outra mãe:<br />
-            <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span> — você pode contar comigo, se se sentir segura.</em>
+              <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span>, você pode contar comigo, se se sentir segura.</em>
           </li>
           <li>Adicionar <span class="hashtag">#mamacircle 💞</span> à sua bio nas redes sociais, para que outras mães saibam que você faz parte do círculo.</li>
-          <li>Você não precisa ser perfeita, só precisa estar presente. Sem cadastro, sem lista — só amor em movimento.</li>
+            <li>Você não precisa ser perfeita, só precisa estar presente. Sem cadastro, sem lista, só amor em movimento.</li>
         </ul>
       </div>
 
-      <p class="note">Não é um app. Nem um grupo. É um círculo sustentado por conexões silenciosas — pequenas trocas, uma mãe por vez.</p>
+        <p class="note">Não é um app. Nem um grupo. É um círculo sustentado por conexões silenciosas, pequenas trocas, uma mãe por vez.</p>
     </section>
 
     <section id="circle" class="wall">
       <h2>Depoimentos do círculo</h2>
-      <p>Essas mães compartilharam o que o <span class="hashtag">#mamacircle 💞</span> significa para elas. Talvez você se veja nessas histórias — ou tome coragem para se aproximar.</p>
+        <p>Essas mães compartilharam o que o <span class="hashtag">#mamacircle 💞</span> significa para elas. Talvez você se veja nessas histórias, ou tome coragem para se aproximar.</p>
 
       <div class="circle-list">
         <!-- Cartões traduzidos podem ser adicionados aqui futuramente -->
@@ -149,7 +150,7 @@
       <div class="footer-grid">
         <div class="footer-left">
           <p><strong>Como participar:</strong><br />
-          Basta adicionar <span class="hashtag">#mamacircle 💞</span> na sua bio ou perfil. Isso mostra para outras mães que você está ali — com carinho, sem pressão, sem regras.</p>
+            Basta adicionar <span class="hashtag">#mamacircle 💞</span> na sua bio ou perfil. Isso mostra para outras mães que você está ali, com carinho, sem pressão, sem regras.</p>
         </div>
         <div class="footer-right">
           <p class="disclaimer-line">

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Mama Circle 💞 is a grassroots space where mothers can gently connect. No sign-ups, no pressure — just gently showing up for one another.">
+    <meta name="description" content="Mama Circle 💞 is a grassroots space where mothers can gently connect. No sign-ups, no pressure, just gently showing up for one another.">
   <meta name="keywords" content="motherhood, support, postpartum, new moms, mom help, mama circle, community, parenting, emotional care" />
   <meta name="author" content="Mama Circle" />
   <meta property="og:title" content="Mama Circle 💞" />
-  <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas — no sign-ups, no judgment." />
+    <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas, no sign-ups, no judgment." />
   <meta property="og:url" content="https://mamacircle.me" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://mamacircle.me/assets/mandala-circle.png" />
@@ -54,13 +54,14 @@
   <main id="top" role="main" class="wrapper">
     <section class="header">
       <img class="logo" src="assets/mandala-circle.png" alt="Mama Circle - Mandala Logo"/>
-      <h1>Mama Circle <span class="strapline"> — a soft place to land in motherhood</span></h1>
+      <h1>Mama Circle</h1>
+      <p class="strapline">A soft place to land in motherhood</p>
 
       <div class="intro">
-        <p>If you're a new mama feeling overwhelmed, emotional, or simply in need of a kind word — this space is for you.</p>
-        <p>Mama Circle is not a group or an app. It's a quiet signal — a simple way for mamas to find one another through <span class="hashtag">#mamacircle 💞</span>.</p>
+        <p>If you're a new mama feeling overwhelmed, emotional, or simply in need of a kind word, this space is for you.</p>
+        <p>Mama Circle is not a group or an app. It's a quiet signal, a simple way for mamas to find one another through <span class="hashtag">#mamacircle 💞</span>.</p>
         <p>You might come across someone who says:<br />
-        <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span> — you can always reach out to me (if it feels safe for you).</em><br />
+        <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</em><br />
        <strong>And they’ll mean it.</strong></p>
       </div>
     </section>
@@ -68,12 +69,12 @@
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">
       <h2 id="manifesto-heading">The Mama Circle Manifesto</h2>
         <ul class="blockquote">
-          <li>When you're tired — <em>we offer understanding.</em></li>
-          <li>When you're overwhelmed — <em>we offer calm.</em></li>
-          <li>When you're unsure — <em>we offer stories.</em></li>
-          <li>When you're lonely — <em>we offer connection.</em></li>
-          <li>When you're lost — <em>we offer each other.</em></li>
-          <li>And if we’re nearby — <em>we’ll bring tea, hold your baby, clean your kitchen, or simply give you a hug.</em></li>
+          <li>When you're tired, <em>we offer understanding.</em></li>
+          <li>When you're overwhelmed, <em>we offer calm.</em></li>
+          <li>When you're unsure, <em>we offer stories.</em></li>
+          <li>When you're lonely, <em>we offer connection.</em></li>
+          <li>When you're lost, <em>we offer each other.</em></li>
+          <li>And if we’re nearby, <em>we’ll bring tea, hold your baby, clean your kitchen, or simply give you a hug.</em></li>
         </ul>
 
         <hr class="divider" />
@@ -86,7 +87,7 @@
           <li>Community <strong>over</strong> competition</li>
         </ul>
 
-        <p class="note">These are the values of Mama Circle — not about being perfect, but being present.</p>
+          <p class="note">These are the values of Mama Circle, not about being perfect, but being present.</p>
     </section>
 
     <section id="how-it-works">
@@ -119,28 +120,28 @@
         <p>If you’re already a mama and want to gently hold space for others, you can:</p>
         <ul>
           <li>Say the Circle Signal when you meet another mother:
-            <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span> — you can always reach out to me (if it feels safe for you).</em>
+            <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</em>
           </li>
           <li>Add <span class="hashtag">#mamacircle 💞</span> to your social media bio, so others know you’re part of the circle.
           </li>
           <li>Visit the <a href="toolkit.html">Toolkit</a> for messages, ideas, and gentle ways to spread the word.</li>
 
-          <li>You don’t need to be perfect, just present. No sign-ups, no lists — just love in motion.</li>
+            <li>You don’t need to be perfect, just present. No sign-ups, no lists, just love in motion.</li>
         </ul>
         
       </div>
     
-      <p class="note">There’s no app. No group. Just a circle held together by quiet connection — one message, one mama at a time.</p>
+        <p class="note">There’s no app. No group. Just a circle held together by quiet connection, one message, one mama at a time.</p>
     </section>
     
 
     <section id="circle" class="wall">
       <h2>Real Words from the Circle</h2>
-      <p>These mamas shared what <span class="hashtag">#mamacircle 💞</span> means to them. Their words might echo your story — or give you the courage to reach out.</p>
+      <p>These mamas shared what <span class="hashtag">#mamacircle 💞</span> means to them. Their words might echo your story, or give you the courage to reach out.</p>
 
       <div class="circle-list">
         <article class="mama-card">
-          <h3>Nati <span>— Perth, Scotland</span></h3>
+          <h3>Nati<span>, Perth, Scotland</span></h3>
           <div class="quote-wrapper">
             <p class="quote">Hello, mamas <3 I'm a proud mum of a beautiful 3-year-old. Being away from family (overseas), it's been a rocky road. Balancing work, marital life and raising a toddler... phew! Aren't we all heroes?</p>
           </div>
@@ -148,7 +149,7 @@
         </article>
 
         <article class="mama-card">
-          <h3>Natalia <span>— Amsterdam, Netherlands</span></h3>
+          <h3>Natalia<span>, Amsterdam, Netherlands</span></h3>
           <div class="quote-wrapper">
             <p class="quote">Sometimes we don't know who to ask that “silly” question, or if it's normal to feel what we’re feeling. When your first baby is born, you are also reborn, and lost, and unsure. I felt completely lost. I hope I can pass along the support I received.</p>
           </div>
@@ -171,7 +172,7 @@
       <div class="footer-grid">
         <div class="footer-left">
           <p><strong>How to join:</strong><br />
-          Just add <span class="hashtag">#mamacircle 💞</span> to your bio or profile. It lets other mamas know you're there — gently, without pressure or rules.</p>
+          Just add <span class="hashtag">#mamacircle 💞</span> to your bio or profile. It lets other mamas know you're there, gently, without pressure or rules.</p>
         </div>
         <div class="footer-right">
           <p class="disclaimer-line">

--- a/privacy.html
+++ b/privacy.html
@@ -7,7 +7,7 @@
   <meta name="keywords" content="motherhood, support, postpartum, new moms, mom help, mama circle, community, parenting, emotional care" />
   <meta name="author" content="Mama Circle" />
   <meta property="og:title" content="Mama Circle 💞" />
-  <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas — no sign-ups, no judgment." />
+    <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas, no sign-ups, no judgment." />
   <meta property="og:url" content="https://mamacircle.me" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://mamacircle.me/assets/mandala-circle.png" />
@@ -45,7 +45,7 @@
         Mama Circle is a grassroots, community-led initiative. It exists to gently connect mothers who wish to support each other with honesty, softness, and care.
       </p>
       <p>
-        This is not a company, coaching service, or moderated platform. You are witnessing — or joining — a self-organized collective of mamas supporting mamas through the quiet signal of <span class="hashtag">#mamacircle 💞</span>.
+          This is not a company, coaching service, or moderated platform. You are witnessing, or joining, a self-organized collective of mamas supporting mamas through the quiet signal of <span class="hashtag">#mamacircle 💞</span>.
       </p>
   
       <h2>What personal data do we collect?</h2>
@@ -58,7 +58,7 @@
   
       <h2>How is your data used?</h2>
       <p>
-        Messages submitted via the form may be featured on the website as part of the Circle — to let other mamas feel seen, held, and reminded they’re not alone.
+          Messages submitted via the form may be featured on the website as part of the Circle, to let other mamas feel seen, held, and reminded they’re not alone.
       </p>
       <p>
         You do not need to list yourself or share any contact info. All messages are optional and softly offered.
@@ -69,7 +69,7 @@
   
       <h2>Community & Safety</h2>
       <p>
-        Mama Circle is not moderated — it relies on trust, shared values, and mutual care.
+          Mama Circle is not moderated, it relies on trust, shared values, and mutual care.
       </p>
       <ul>
         <li>No accounts or logins are needed. You can browse anonymously.</li>
@@ -95,7 +95,7 @@
       <hr />
   
       <p>
-        Mama Circle is about care — not control. Let’s protect each other with love, boundaries, and presence. <strong>Thank you for being part of this. 💞</strong>
+          Mama Circle is about care, not control. Let’s protect each other with love, boundaries, and presence. <strong>Thank you for being part of this. 💞</strong>
       </p>
     </section>
   </main>

--- a/toolkit.html
+++ b/toolkit.html
@@ -7,7 +7,7 @@
   <meta name="keywords" content="motherhood, support, postpartum, new moms, mom help, mama circle, community, parenting, emotional care" />
   <meta name="author" content="Mama Circle" />
   <meta property="og:title" content="Mama Circle 💞" />
-  <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas — no sign-ups, no judgment." />
+    <meta property="og:description" content="A soft place to land in motherhood. Mamas supporting mamas, no sign-ups, no judgment." />
   <meta property="og:url" content="https://mamacircle.me/toolkit.html" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://mamacircle.me/assets/mandala-circle.png" />
@@ -39,7 +39,7 @@
 
   <main class="wrapper" role="main">
       <h1>Toolkit</h1>
-      <p>This page includes simple ways you can help others discover the Circle. Whether you’ve been helped or want to offer support — here’s how you can spread the word, softly and kindly.</p>
+        <p>This page includes simple ways you can help others discover the Circle. Whether you’ve been helped or want to offer support, here’s how you can spread the word, softly and kindly.</p>
       <p>Share the circle. Let it ripple out. 💞</p>
 
       <section id="sharable-quotes" class="section-box">
@@ -47,18 +47,18 @@
       <p>Share one of these little messages in your bio, stories, group chats, or anywhere it feels right:</p>
     <ul class="quote-list">
         <li>
-            <p class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span> — you can always reach out to me (if it feels safe for you).</p>
+              <p class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</p>
         </li>
 
         <li>
-            <p class="quote">You’re not alone. Look up <span class="hashtag">#mamacircle 💞</span> — a gentle way to find other mamas.</p>
+              <p class="quote">You’re not alone. Look up <span class="hashtag">#mamacircle 💞</span>, a gentle way to find other mamas.</p>
         </li>
 
         <li>
-            <p class="quote"><span class="hashtag">#mamacircle 💞</span> is not a group or app — just a quiet signal of care between mamas.</p>
+              <p class="quote"><span class="hashtag">#mamacircle 💞</span> is not a group or app, just a quiet signal of care between mamas.</p>
         </li>
         <li>
-            <p class="quote">I'm part of <span class="hashtag">#mamacircle 💞</span> — gentle support from mama to mama.</p>
+              <p class="quote">I'm part of <span class="hashtag">#mamacircle 💞</span>, gentle support from mama to mama.</p>
         </li>
       </ul>
       </section>
@@ -69,13 +69,13 @@
       
         <h3>For a new mama</h3>
         <div class="copy-block">
-          <p class="quote">Hey mama, just wanted to say — I’m here if you ever need to talk, cry, vent, or just not feel so alone. I’m part of <span class="hashtag">#mamacircle 💞</span>, a gentle way mamas show up for each other. If you're curious, there's more about it here: <a href="https://mamacircle.me" target="_blank">mamacircle.me</a>
+            <p class="quote">Hey mama, just wanted to say, I’m here if you ever need to talk, cry, vent, or just not feel so alone. I’m part of <span class="hashtag">#mamacircle 💞</span>, a gentle way mamas show up for each other. If you're curious, there's more about it here: <a href="https://mamacircle.me" target="_blank">mamacircle.me</a>
           </p>
         </div>
       <hr />
         <h3>For a mama who wants to support others</h3>
         <div class="copy-block">
-          <p class="quote">You have such a kind heart — I think you'd love this grassroots project called <span class="hashtag">#mamacircle 💞</span>. It's a way for mamas to gently say “I'm here if you need me.” You can simply add the hashtag to your profile and read more here: <a href="https://mamacircle.me" target="_blank">mamacircle.me</a></p>
+            <p class="quote">You have such a kind heart, I think you'd love this grassroots project called <span class="hashtag">#mamacircle 💞</span>. It's a way for mamas to gently say “I'm here if you need me.” You can simply add the hashtag to your profile and read more here: <a href="https://mamacircle.me" target="_blank">mamacircle.me</a></p>
         </div>
       </section>
       
@@ -93,7 +93,7 @@
       <section id="sharable-visuals" class="section-box">
         <h2>Add a visual</h2>
         <code>COMING SOON</code>
-        <p>We’re designing sweet visuals you can share soon — story slides, badges, and more. If you’d like to contribute or share ideas, <a href="mailto:hello@mamacircle.me">drop us a line</a> 💌</p>
+          <p>We’re designing sweet visuals you can share soon, story slides, badges, and more. If you’d like to contribute or share ideas, <a href="mailto:hello@mamacircle.me">drop us a line</a> 💌</p>
       </section>
 
       


### PR DESCRIPTION
## Summary
- rewrite dash-separated phrases with commas across site content
- move landing straplines into their own paragraphs for clarity
- update toolkit, code-of-care, and privacy pages to avoid dash punctuation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689799e73aac832a87802201a5f32a43