### PR TITLE
refactor: consolidate DOM initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,38 +1,37 @@
-
-document.addEventListener("DOMContentLoaded", function () {
-  const tabs = document.querySelectorAll(".tab");
-  const contents = document.querySelectorAll(".tab-content");
+document.addEventListener('DOMContentLoaded', () => {
+  const tabs = document.querySelectorAll('.tab');
+  const contents = document.querySelectorAll('.tab-content');
 
   tabs.forEach((tab) => {
-    tab.addEventListener("click", function () {
-      const target = this.getAttribute("data-tab");
+    tab.addEventListener('click', function () {
+      const target = this.getAttribute('data-tab');
 
       tabs.forEach((t) => {
-        t.classList.remove("active");
-        t.setAttribute("aria-selected", "false");
+        t.classList.remove('active');
+        t.setAttribute('aria-selected', 'false');
       });
 
       contents.forEach((c) => {
-        c.classList.remove("active");
-        c.setAttribute("hidden", "true");
+        c.classList.remove('active');
+        c.setAttribute('hidden', 'true');
       });
 
-      this.classList.add("active");
-      this.setAttribute("aria-selected", "true");
+      this.classList.add('active');
+      this.setAttribute('aria-selected', 'true');
       const content = document.getElementById(target);
-      content.classList.add("active");
-      content.removeAttribute("hidden");
+      content.classList.add('active');
+      content.removeAttribute('hidden');
     });
 
     // Keyboard accessibility
-    tab.addEventListener("keydown", function (e) {
+    tab.addEventListener('keydown', function (e) {
       const index = Array.from(tabs).indexOf(document.activeElement);
-      if (e.key === "ArrowRight") {
+      if (e.key === 'ArrowRight') {
         e.preventDefault();
         const next = tabs[(index + 1) % tabs.length];
         next.focus();
         next.click();
-      } else if (e.key === "ArrowLeft") {
+      } else if (e.key === 'ArrowLeft') {
         e.preventDefault();
         const prev = tabs[(index - 1 + tabs.length) % tabs.length];
         prev.focus();
@@ -42,32 +41,30 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   // Initial ARIA setup
-  contents.forEach((c, i) => {
-    c.setAttribute("role", "tabpanel");
-    if (!c.classList.contains("active")) c.setAttribute("hidden", "true");
+  contents.forEach((c) => {
+    c.setAttribute('role', 'tabpanel');
+    if (!c.classList.contains('active')) c.setAttribute('hidden', 'true');
   });
 
-  tabs.forEach((tab, i) => {
-    tab.setAttribute("tabindex", "0");
+  tabs.forEach((tab) => {
+    tab.setAttribute('tabindex', '0');
   });
-});
 
+  // Navigation toggle
+  const toggleButton = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('.site-nav');
 
-const toggleButton = document.querySelector('.menu-toggle');
-const nav = document.querySelector('.site-nav');
+  toggleButton.addEventListener('click', () => {
+    const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
+    toggleButton.setAttribute('aria-expanded', !expanded);
+    nav.classList.toggle('open');
+  });
 
-toggleButton.addEventListener('click', () => {
-  const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
-  toggleButton.setAttribute('aria-expanded', !expanded);
-  nav.classList.toggle('open');
-});
-
-
-document.addEventListener('DOMContentLoaded', () => {
+  // Language highlighting
   const langLinks = document.querySelectorAll('.lang-link');
   const currentPage = window.location.pathname;
 
-  langLinks.forEach(link => {
+  langLinks.forEach((link) => {
     const href = link.getAttribute('href');
     if (currentPage.endsWith(href)) {
       link.classList.add('current');


### PR DESCRIPTION
## Summary
- initialize tabs, navigation menu, and language highlighting in a single `DOMContentLoaded` handler for streamlined execution

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979c7a40b0832aa4de67f8f37080a7