### PR TITLE
Refactor show-more control to button with JS listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
           <div class="quote-wrapper">
             <p class="quote">Hello, mamas <3 I'm a proud mum of a beautiful 3-year-old. Being away from family (overseas), it's been a rocky road. Balancing work, marital life and raising a toddler... phew! Aren't we all heroes?</p>
           </div>
-          <span class="show-more" onclick="this.closest('.mama-card').classList.toggle('expanded')">Show more</span>
+          <button class="show-more" type="button" aria-expanded="false">Show more</button>
         </article>
 
         <article class="mama-card">
@@ -153,7 +153,7 @@
           <div class="quote-wrapper">
             <p class="quote">Sometimes we don't know who to ask that “silly” question, or if it's normal to feel what we’re feeling. When your first baby is born, you are also reborn, and lost, and unsure. I felt completely lost. I hope I can pass along the support I received.</p>
           </div>
-          <span class="show-more" onclick="this.closest('.mama-card').classList.toggle('expanded')">Show more</span>
+          <button class="show-more" type="button" aria-expanded="false">Show more</button>
         </article>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -73,4 +73,14 @@ document.addEventListener('DOMContentLoaded', () => {
       link.classList.add('current');
     }
   });
+
+  const showMoreButtons = document.querySelectorAll('.show-more');
+  showMoreButtons.forEach(button => {
+    button.setAttribute('aria-expanded', 'false');
+    button.addEventListener('click', () => {
+      const card = button.closest('.mama-card');
+      const expanded = card.classList.toggle('expanded');
+      button.setAttribute('aria-expanded', expanded);
+    });
+  });
 });

--- a/style.css
+++ b/style.css
@@ -418,6 +418,9 @@ section {
   text-decoration: underline;
   cursor: pointer;
   margin-top: 0.3rem;
+  background: none;
+  border: none;
+  padding: 0;
 }
 
 /* === Contact Info === */


### PR DESCRIPTION
## Summary
- Replace inline `show-more` spans with accessible button elements
- Move inline toggle logic into `script.js` and manage `aria-expanded`
- Style new `.show-more` buttons in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979c8bc6c4832abf7d38c40e9416cd