### PR TITLE
Treat root path as index for language link highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,7 +65,7 @@ toggleButton.addEventListener('click', () => {
 
 document.addEventListener('DOMContentLoaded', () => {
   const langLinks = document.querySelectorAll('.lang-link');
-  const currentPage = window.location.pathname;
+  const currentPage = window.location.pathname.replace(/\/$/, '/index.html');
 
   langLinks.forEach(link => {
     const href = link.getAttribute('href');


### PR DESCRIPTION
## Summary
- Ensure language links highlight current page when URL is '/' or '/index.html'

## Testing
- `node - <<'NODE' ...`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979c82f3cc832a9cb56f1f9d933fa5