### PR TITLE
fix: guard mobile menu toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,11 +56,13 @@ document.addEventListener("DOMContentLoaded", function () {
 const toggleButton = document.querySelector('.menu-toggle');
 const nav = document.querySelector('.site-nav');
 
-toggleButton.addEventListener('click', () => {
-  const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
-  toggleButton.setAttribute('aria-expanded', !expanded);
-  nav.classList.toggle('open');
-});
+if (toggleButton && nav) {
+  toggleButton.addEventListener('click', () => {
+    const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
+    toggleButton.setAttribute('aria-expanded', !expanded);
+    nav.classList.toggle('open');
+  });
+}
 
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- avoid runtime errors on pages lacking the mobile menu by checking for menu elements before attaching toggle

## Testing
- `node --check script.js && echo 'Syntax OK'`
- `node <<'NODE'
    global.window = { location: { pathname: '/privacy.html' } };
    function makeElement() {
      return {
        classList: { add(){}, remove(){}, toggle(){} },
        setAttribute(){},
        getAttribute(){ return null; },
        addEventListener(){},
        removeAttribute(){},
      };
    }
    global.document = {
      addEventListener: (event, handler) => { if (event === 'DOMContentLoaded') handler(); },
      querySelector: () => null,
      querySelectorAll: () => ({ forEach: () => {} }),
      getElementById: () => makeElement(),
    };
    require('./script.js');
    console.log('Script executed without error');
    NODE`
- `npm test` *(fails: Could not read package.json: Error: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68979cdd82a8832a917856f035da40c9