### PR TITLE
Add aria-hidden to decorative menu and tab icons

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -34,7 +34,7 @@
     <div class="nav-container">
       <div class="site-branding"><a href="#top">Mama Circle</a></div>
       <button class="menu-toggle" aria-label="Alternar menu" aria-expanded="false">
-        <i class="fa-solid fa-bars"></i>
+        <i class="fa-solid fa-bars" aria-hidden="true"></i>
       </button>
       <nav class="site-nav">
         <ul>
@@ -95,10 +95,10 @@
 
       <div class="tabs" role="tablist" aria-label="Papéis no Mama Circle">
         <button class="tab active" data-tab="new-mamas" role="tab" aria-selected="true" aria-controls="new-mamas" id="tab-new">
-          <i class="fa-solid fa-baby"></i> Para novas mães
+          <i class="fa-solid fa-baby" aria-hidden="true"></i> Para novas mães
         </button>
         <button class="tab" data-tab="supporters" role="tab" aria-selected="false" aria-controls="supporters" id="tab-supporters">
-          <i class="fa-solid fa-hand-holding-heart"></i> Para apoiadoras
+          <i class="fa-solid fa-hand-holding-heart" aria-hidden="true"></i> Para apoiadoras
         </button>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <div class="nav-container">
       <div class="site-branding"><a href="#top">Mama Circle</a></div>
       <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
-        <i class="fa-solid fa-bars"></i>
+        <i class="fa-solid fa-bars" aria-hidden="true"></i>
       </button>
       <nav class="site-nav">
         <ul>
@@ -96,10 +96,10 @@
     
       <div class="tabs" role="tablist" aria-label="Mama Circle roles">
         <button class="tab active" data-tab="new-mamas" role="tab" aria-selected="true" aria-controls="new-mamas" id="tab-new">
-          <i class="fa-solid fa-baby"></i> For New Mamas
+          <i class="fa-solid fa-baby" aria-hidden="true"></i> For New Mamas
         </button>
         <button class="tab" data-tab="supporters" role="tab" aria-selected="false" aria-controls="supporters" id="tab-supporters">
-          <i class="fa-solid fa-hand-holding-heart"></i> For Supporters
+          <i class="fa-solid fa-hand-holding-heart" aria-hidden="true"></i> For Supporters
         </button>
       </div>
     


### PR DESCRIPTION
## Summary
- Hide decorative icons in menu toggle from assistive tech with `aria-hidden="true"`
- Mark tab button icons as aria-hidden so text labels remain accessible

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979f4624dc832a9d51982dfb20511e