### PR TITLE
Improve language switcher accessibility

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -42,9 +42,12 @@
           <li><a href="#how-it-works">Como funciona</a></li>
           <li><a href="#circle">Depoimentos</a></li>
           <li><a href="code-of-care.html">Código de Cuidado</a></li>
-          <li class="language-switcher">
-            <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt">PT</a> |
-            <a href="index.html" lang="en" class="lang-link" data-lang="en">EN</a>
+          <li>
+            <nav class="language-switcher" aria-label="Language switcher">
+              <a href="index-pt.html" lang="pt" class="lang-link current" data-lang="pt" aria-label="Ver site em Português" aria-current="page">PT</a>
+              <span aria-hidden="true">|</span>
+              <a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="View site in English">EN</a>
+            </nav>
           </li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,12 @@
           <li><a href="#how-it-works">How it works</a></li>
           <li><a href="#circle">Stories</a></li>
           <li><a href="code-of-care.html">Code of Care</a></li>
-          <li class="language-switcher">
-            <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt">PT</a> |
-            <a href="index.html" lang="en" class="lang-link" data-lang="en">EN</a>
+          <li>
+            <nav class="language-switcher" aria-label="Language switcher">
+              <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="View site in Portuguese">PT</a>
+              <span aria-hidden="true">|</span>
+              <a href="index.html" lang="en" class="lang-link current" data-lang="en" aria-label="View site in English" aria-current="page">EN</a>
+            </nav>
           </li>
           
         </ul>

--- a/script.js
+++ b/script.js
@@ -68,6 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const href = link.getAttribute('href');
     if (currentPage.endsWith(href)) {
       link.classList.add('current');
+      link.setAttribute('aria-current', 'page');
     }
   });
 


### PR DESCRIPTION
## Summary
- wrap language toggle links in a nav labeled "Language switcher" and hide decorative pipe
- mark active language with `aria-current` and descriptive labels
- update script to set `aria-current` on the current language link

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68979f289fc8832a9be38effbfd17c13