### PR TITLE
Add skip links for accessible main navigation

### DIFF
--- a/code-of-care.html
+++ b/code-of-care.html
@@ -28,6 +28,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
       <div class="internal"><span class="site-branding"><a href="index.html">Mama Circle</a></span> |
@@ -35,7 +36,7 @@
     </div>
     </div>
   </header>
-  <main class="wrapper" role="main">
+  <main id="main" class="wrapper" role="main" tabindex="-1">
     
     <section class="code-of-care">
       <h1>Code of Care</h1>

--- a/index-pt.html
+++ b/index-pt.html
@@ -29,10 +29,10 @@
 </head>
 
 <body>
-  <a class="skip-link" href="#top">Pular para o conteúdo</a>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
-      <div class="site-branding"><a href="#top">Mama Circle</a></div>
+      <div class="site-branding"><a href="#main">Mama Circle</a></div>
       <button class="menu-toggle" aria-label="Alternar menu" aria-expanded="false">
         <i class="fa-solid fa-bars"></i>
       </button>
@@ -51,7 +51,7 @@
     </div>
   </header>
 
-  <main id="top" role="main" class="wrapper">
+  <main id="main" role="main" class="wrapper" tabindex="-1">
     <section class="header">
       <img class="logo" src="assets/mandala-circle.png" alt="Logo Mama Circle - Mandala"/>
       <h1>Mama Circle</h1>

--- a/index.html
+++ b/index.html
@@ -29,10 +29,10 @@
 </head>
 
 <body>
-  <a class="skip-link" href="#top">Skip to content</a>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
-      <div class="site-branding"><a href="#top">Mama Circle</a></div>
+      <div class="site-branding"><a href="#main">Mama Circle</a></div>
       <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
         <i class="fa-solid fa-bars"></i>
       </button>
@@ -52,7 +52,7 @@
     </div>
   </header>
 
-  <main id="top" role="main" class="wrapper">
+  <main id="main" role="main" class="wrapper" tabindex="-1">
     <section class="header">
       <img class="logo" src="assets/mandala-circle.png" alt="Mama Circle - Mandala Logo"/>
       <h1>Mama Circle</h1>

--- a/privacy.html
+++ b/privacy.html
@@ -28,6 +28,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
       <div class="internal"><span class="site-branding"><a href="index.html">Mama Circle</a></span> |
@@ -35,7 +36,7 @@
     </div>
     </div>
   </header>
-  <main class="wrapper" role="main">
+  <main id="main" class="wrapper" role="main" tabindex="-1">
     <section class="privacy">
       <h1>Privacy & Safety</h1>
       <p class="note">Last updated: March 2025</p>

--- a/toolkit.html
+++ b/toolkit.html
@@ -29,6 +29,7 @@
 </head>
 
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <div class="nav-container">
       <div class="internal"><span class="site-branding"><a href="index.html">Mama Circle</a></span> |
@@ -37,7 +38,7 @@
     </div>
   </header>
 
-  <main class="wrapper" role="main">
+  <main id="main" class="wrapper" role="main" tabindex="-1">
       <h1>Toolkit</h1>
         <p>This page includes simple ways you can help others discover the Circle. Whether you’ve been helped or want to offer support, here’s how you can spread the word, softly and kindly.</p>
       <p>Share the circle. Let it ripple out. 💞</p>


### PR DESCRIPTION
## Summary
- Add skip links at the start of each page and target the main landmark
- Mark main content wrappers with `id="main"` and `tabindex="-1"` for keyboard focus

## Testing
- `node -e "const fs=require('fs');const files=['index.html','index-pt.html','code-of-care.html','privacy.html','toolkit.html'];for(const f of files){const c=fs.readFileSync(f,'utf8');console.log(f,c.includes('<a class=\"skip-link\" href=\"#main\">Skip to content</a>'),c.includes('<main id=\"main\"'));}"`
- `npx --yes html-validate index.html index-pt.html code-of-care.html privacy.html toolkit.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68979f4dc858832a85139db89316498e