### PR TITLE
Add ARIA controls to quote toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,18 +143,18 @@
       <div class="circle-list">
         <article class="mama-card">
           <h3>Nati<span>, Perth, Scotland</span></h3>
-          <div class="quote-wrapper">
+          <div class="quote-wrapper" id="quote-nati">
             <p class="quote">Hello, mamas <3 I'm a proud mum of a beautiful 3-year-old. Being away from family (overseas), it's been a rocky road. Balancing work, marital life and raising a toddler... phew! Aren't we all heroes?</p>
           </div>
-          <button class="show-more" type="button" aria-expanded="false">Show more</button>
+          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-nati">Show more</button>
         </article>
 
         <article class="mama-card">
           <h3>Natalia<span>, Amsterdam, Netherlands</span></h3>
-          <div class="quote-wrapper">
+          <div class="quote-wrapper" id="quote-natalia">
             <p class="quote">Sometimes we don't know who to ask that “silly” question, or if it's normal to feel what we’re feeling. When your first baby is born, you are also reborn, and lost, and unsure. I felt completely lost. I hope I can pass along the support I received.</p>
           </div>
-          <button class="show-more" type="button" aria-expanded="false">Show more</button>
+          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-natalia">Show more</button>
         </article>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -72,12 +72,12 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const showMoreButtons = document.querySelectorAll('.show-more');
-  showMoreButtons.forEach(button => {
-    button.setAttribute('aria-expanded', 'false');
+  showMoreButtons.forEach((button) => {
     button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
       const card = button.closest('.mama-card');
-      const expanded = card.classList.toggle('expanded');
-      button.setAttribute('aria-expanded', expanded);
+      card.classList.toggle('expanded', !expanded);
+      button.setAttribute('aria-expanded', String(!expanded));
     });
   });
 });

--- a/style.css
+++ b/style.css
@@ -421,6 +421,7 @@ section {
   background: none;
   border: none;
   padding: 0;
+  font: inherit;
 }
 
 /* === Contact Info === */


### PR DESCRIPTION
## Summary
- Give quote wrappers stable IDs and connect show-more buttons via `aria-controls`
- Toggle `aria-expanded` on show-more buttons in `script.js`
- Style `.show-more` button to inherit font settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979f481514832a9efc5e0e1c28cbb5