### PR TITLE
Improve language switcher accessibility

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -42,9 +42,12 @@
           <li><a href="#how-it-works">Como funciona</a></li>
           <li><a href="#circle">Depoimentos</a></li>
           <li><a href="code-of-care.html">Código de Cuidado</a></li>
-          <li class="language-switcher">
-            <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt">PT</a> |
-            <a href="index.html" lang="en" class="lang-link" data-lang="en">EN</a>
+          <li>
+            <nav class="language-switcher" aria-label="Language switcher">
+              <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="Ver site em português" aria-current="page">PT</a>
+              <span class="separator" aria-hidden="true">|</span>
+              <a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="Ver site em inglês">EN</a>
+            </nav>
           </li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,12 @@
           <li><a href="#how-it-works">How it works</a></li>
           <li><a href="#circle">Stories</a></li>
           <li><a href="code-of-care.html">Code of Care</a></li>
-          <li class="language-switcher">
-            <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt">PT</a> |
-            <a href="index.html" lang="en" class="lang-link" data-lang="en">EN</a>
+          <li>
+            <nav class="language-switcher" aria-label="Language switcher">
+              <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="View site in Portuguese">PT</a>
+              <span class="separator" aria-hidden="true">|</span>
+              <a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="View site in English" aria-current="page">EN</a>
+            </nav>
           </li>
           
         </ul>

--- a/script.js
+++ b/script.js
@@ -68,6 +68,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const href = link.getAttribute('href');
     if (currentPage.endsWith(href)) {
       link.classList.add('current');
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -328,6 +328,10 @@ section {
   color: var(--accent);
 }
 
+.language-switcher .separator {
+  opacity: 0.6;
+}
+
 
 .note {
   font-size: var(--font-sm);


### PR DESCRIPTION
## Summary
- Add `aria-label` and `aria-current` to language switcher links and wrap them in a dedicated navigation element
- Hide decorative separator from assistive tech and style with CSS
- Update script to set `aria-current` dynamically for current language

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979f2f16a8832aadacd282e22169cc