### PR TITLE
Improve tab accessibility handling

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -115,7 +115,7 @@
         </ul>
       </div>
 
-      <div class="tab-content section-box highlighted" id="supporters" role="tabpanel" aria-labelledby="tab-supporters">
+      <div class="tab-content section-box highlighted" id="supporters" role="tabpanel" aria-labelledby="tab-supporters" hidden>
         <h3>Mostre seu apoio.</h3>
         <p>Se você já é mãe e quer estar disponível com intenção para novas mães, você pode:</p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
         </ul>
       </div>
     
-      <div class="tab-content section-box highlighted" id="supporters" role="tabpanel" aria-labelledby="tab-supporters">
+      <div class="tab-content section-box highlighted" id="supporters" role="tabpanel" aria-labelledby="tab-supporters" hidden>
         <h3>Show your support.</h3>
         <p>If you’re already a mama and want to gently hold space for others, you can:</p>
         <ul>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
       tabs.forEach((t) => {
         t.classList.remove('active');
         t.setAttribute('aria-selected', 'false');
+        t.setAttribute('tabindex', '-1');
       });
 
       contents.forEach((c) => {
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       this.classList.add('active');
       this.setAttribute('aria-selected', 'true');
+      this.setAttribute('tabindex', '0');
       const content = document.getElementById(target);
       content.classList.add('active');
       content.removeAttribute('hidden');
@@ -43,11 +45,17 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initial ARIA setup
   contents.forEach((c) => {
     c.setAttribute('role', 'tabpanel');
-    if (!c.classList.contains('active')) c.setAttribute('hidden', 'true');
+    if (!c.classList.contains('active')) {
+      c.setAttribute('hidden', 'true');
+    } else {
+      c.removeAttribute('hidden');
+    }
   });
 
   tabs.forEach((tab) => {
-    tab.setAttribute('tabindex', '0');
+    const isActive = tab.classList.contains('active');
+    tab.setAttribute('tabindex', isActive ? '0' : '-1');
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
   });
 
   // Navigation toggle


### PR DESCRIPTION
## Summary
- Hide inactive tab panels by default
- Manage tabindex, aria-selected, and hidden attributes as tabs change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979f42a7b0832a8082da761233f4e7