### PR TITLE
Add modern theme and URL-based switching

### DIFF
--- a/code-of-care.html
+++ b/code-of-care.html
@@ -86,6 +86,7 @@
       </p>
     </section>
   </main>
-  
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -100,7 +100,7 @@
       </p>
     </section>
   </main>
-  
-  
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const theme = params.get('theme');
+  if (theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+
   const tabs = document.querySelectorAll('.tab');
   const contents = document.querySelectorAll('.tab-content');
 
@@ -62,11 +68,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const toggleButton = document.querySelector('.menu-toggle');
   const nav = document.querySelector('.site-nav');
 
-  toggleButton.addEventListener('click', () => {
-    const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
-    toggleButton.setAttribute('aria-expanded', !expanded);
-    nav.classList.toggle('open');
-  });
+  if (toggleButton && nav) {
+    toggleButton.addEventListener('click', () => {
+      const expanded = toggleButton.getAttribute('aria-expanded') === 'true' || false;
+      toggleButton.setAttribute('aria-expanded', !expanded);
+      nav.classList.toggle('open');
+    });
+  }
 
   // Language highlighting
   const langLinks = document.querySelectorAll('.lang-link');

--- a/style.css
+++ b/style.css
@@ -29,6 +29,23 @@
   --border: #444;
 }
 
+/* === Modern Theme === */
+[data-theme="modern"] {
+  --background: #ffffff;
+  --text: #222222;
+  --headline: #0d0d0d;
+  --accent: #007bff;
+  --surface: #f5f5f5;
+  --surface-muted: #e5e5e5;
+  --border: #cccccc;
+}
+
+[data-theme="modern"] h1,
+[data-theme="modern"] h2,
+[data-theme="modern"] h3 {
+  font-family: 'Inter', sans-serif;
+}
+
 /* === Base === */
 html {
   font-size: 100%;

--- a/toolkit.html
+++ b/toolkit.html
@@ -102,5 +102,6 @@
         <p><strong>Thank you</strong> for helping build this gentle web of connection. 💞</p>
       </footer>
   </main>
+  <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a `modern` theme with new color palette and heading fonts
- allow selecting a theme via `?theme=` URL query parameter
- safely handle missing navigation elements and load script on static pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a1aa3ce8832a9b094f162bc8364b