### PR TITLE
Improve language switcher accessibility

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -44,9 +44,10 @@
           <li><a href="code-of-care.html">Código de Cuidado</a></li>
           <li>
             <nav class="language-switcher" aria-label="Language switcher">
-              <a href="index-pt.html" lang="pt" class="lang-link current" data-lang="pt" aria-label="Ver site em Português" aria-current="page">PT</a>
-              <span aria-hidden="true">|</span>
-              <a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="View site in English">EN</a>
+              <ul>
+                <li><a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="Ver site em Português">PT</a></li>
+                <li><a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="View site in English">EN</a></li>
+              </ul>
             </nav>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -44,9 +44,10 @@
           <li><a href="code-of-care.html">Code of Care</a></li>
           <li>
             <nav class="language-switcher" aria-label="Language switcher">
-              <a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="View site in Portuguese">PT</a>
-              <span aria-hidden="true">|</span>
-              <a href="index.html" lang="en" class="lang-link current" data-lang="en" aria-label="View site in English" aria-current="page">EN</a>
+              <ul>
+                <li><a href="index-pt.html" lang="pt" class="lang-link" data-lang="pt" aria-label="View site in Portuguese">PT</a></li>
+                <li><a href="index.html" lang="en" class="lang-link" data-lang="en" aria-label="View site in English">EN</a></li>
+              </ul>
             </nav>
           </li>
           

--- a/script.js
+++ b/script.js
@@ -70,13 +70,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Language highlighting
   const langLinks = document.querySelectorAll('.lang-link');
-  const currentPage = window.location.pathname.replace(/\/$/, '/index.html');
+  const currentLang = document.documentElement.lang;
 
   langLinks.forEach((link) => {
-    const href = link.getAttribute('href');
-    if (currentPage.endsWith(href)) {
+    const linkLang = link.getAttribute('lang');
+    if (linkLang === currentLang) {
       link.classList.add('current');
       link.setAttribute('aria-current', 'page');
+    } else {
+      link.classList.remove('current');
+      link.removeAttribute('aria-current');
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -303,9 +303,20 @@ section {
 .language-switcher {
   font-size: var(--font-sm);
   font-weight: 500;
+}
+
+.language-switcher ul {
+  list-style: none;
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.language-switcher li + li {
+  border-left: 1px solid var(--headline);
+  padding-left: 0.25rem;
 }
 
 .language-switcher a {


### PR DESCRIPTION
## Summary
- Wrap language links in dedicated nav with list structure and accessible labels
- Style language switcher via CSS and drop decorative separators
- Detect current language and set `aria-current` dynamically in script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a2842378832ab2657d1295964531