### PR TITLE
Use :focus-visible for keyboard navigation outlines with fallback

### DIFF
--- a/style.css
+++ b/style.css
@@ -89,7 +89,7 @@ a {
   transition: color 0.2s ease;
 }
 a:hover,
-a:focus {
+a:focus-visible {
   color: var(--accent);
   text-decoration: none;
 }
@@ -129,7 +129,7 @@ ul {
 }
 
 /* === Accessibility === */
-:focus {
+:focus-visible {
   outline: 2px dashed var(--accent);
   outline-offset: 4px;
 }
@@ -142,7 +142,7 @@ ul {
   padding: 0.5rem;
   z-index: 100;
 }
-.skip-link:focus { top: 0; }
+.skip-link:focus-visible { top: 0; }
 
 /* === Layout === */
 main {
@@ -346,7 +346,7 @@ section {
 }
 
 .language-switcher a:hover,
-.language-switcher a:focus {
+.language-switcher a:focus-visible {
   opacity: 1;
   color: var(--accent);
 }
@@ -355,6 +355,25 @@ section {
   font-weight: 600;
   opacity: 1;
   color: var(--accent);
+}
+
+@supports not selector(:focus-visible) {
+  a:focus {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  :focus {
+    outline: 2px dashed var(--accent);
+    outline-offset: 4px;
+  }
+
+  .skip-link:focus { top: 0; }
+
+  .language-switcher a:focus {
+    opacity: 1;
+    color: var(--accent);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- replace :focus styles with :focus-visible so outlines appear only for keyboard navigation
- add @supports fallback :focus styles for browsers without :focus-visible

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mamacircle/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6897a89e2484832aaf67f6f8c223bc37