### PR TITLE
Add responsive media queries for small and large screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -539,3 +539,56 @@ section {
   padding: 1rem 1.5rem;
 }
 
+/* === Responsive Tweaks === */
+@media (max-width: 480px) {
+  html {
+    font-size: 90%;
+  }
+  main {
+    padding: 1rem 0.5rem;
+  }
+  section {
+    margin: 1.5rem 0;
+  }
+  h1 {
+    font-size: var(--font-xl);
+  }
+  h2 {
+    font-size: var(--font-lg);
+  }
+  h3 {
+    font-size: var(--font-md);
+  }
+  .section-box {
+    padding: 1rem;
+  }
+  .footer-grid {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+}
+
+@media (min-width: 1024px) {
+  html {
+    font-size: 112.5%;
+  }
+  main {
+    max-width: 900px;
+    padding: 3rem 0;
+  }
+  section {
+    margin: 3rem 0;
+  }
+  .nav-container {
+    max-width: 1200px;
+  }
+  .footer-grid {
+    max-width: 1200px;
+    gap: 3rem;
+  }
+  .mama-card {
+    flex: 0 0 300px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Introduce responsive media queries for screens ≤480px and ≥1024px
- Adjust fonts, spacing, and layout within new breakpoints for better readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a8cde2f4832ab3e63faed48434f2