### PR TITLE
Add SEO resources for site discoverability

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -16,6 +16,9 @@
   <meta name="twitter:description" content="Um lugar gentil para pousar na maternidade." />
   <meta name="twitter:image" content="https://mamacircle.me/assets/mandala-circle.png" />
   <link rel="canonical" href="https://mamacircle.me" />
+  <link rel="alternate" href="https://mamacircle.me/index.html" hreflang="en" />
+  <link rel="alternate" href="https://mamacircle.me/index-pt.html" hreflang="pt" />
+  <link rel="alternate" href="https://mamacircle.me" hreflang="x-default" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -26,6 +29,15 @@
   <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital@1&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Mama Circle",
+    "url": "https://mamacircle.me",
+    "logo": "https://mamacircle.me/assets/mandala-circle.png"
+  }
+  </script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
   <meta name="twitter:description" content="A soft place to land in motherhood." />
   <meta name="twitter:image" content="https://mamacircle.me/assets/mandala-circle.png" />
   <link rel="canonical" href="https://mamacircle.me" />
+  <link rel="alternate" href="https://mamacircle.me/index.html" hreflang="en" />
+  <link rel="alternate" href="https://mamacircle.me/index-pt.html" hreflang="pt" />
+  <link rel="alternate" href="https://mamacircle.me" hreflang="x-default" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -26,6 +29,15 @@
   <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital@1&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Mama Circle",
+    "url": "https://mamacircle.me",
+    "logo": "https://mamacircle.me/assets/mandala-circle.png"
+  }
+  </script>
 </head>
 
 <body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mamacircle.me/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://mamacircle.me/</loc></url>
+  <url><loc>https://mamacircle.me/index-pt.html</loc></url>
+  <url><loc>https://mamacircle.me/code-of-care.html</loc></url>
+  <url><loc>https://mamacircle.me/privacy.html</loc></url>
+  <url><loc>https://mamacircle.me/toolkit.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add robots.txt and sitemap.xml so search engines can index the site
- cross-link language versions and embed basic Organization JSON-LD metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a968d0c0832a9458952f7665c074