### PR TITLE
Style header section as full-page hero

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -76,6 +76,7 @@
           <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span>, você pode contar comigo, se se sentir segura.</em><br />
         <strong>E ela diz com intenção.</strong></p>
       </div>
+      <a class="button" href="#how-it-works">Saiba como funciona</a>
     </section>
 
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">

--- a/index.html
+++ b/index.html
@@ -74,8 +74,9 @@
         <p>Mama Circle is not a group or an app. It's a quiet signal, a simple way for mamas to find one another through <span class="hashtag">#mamacircle 💞</span>.</p>
         <p>You might come across someone who says:<br />
         <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</em><br />
-       <strong>And they’ll mean it.</strong></p>
+      <strong>And they’ll mean it.</strong></p>
       </div>
+      <a class="button" href="#how-it-works">Learn how it works</a>
     </section>
 
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">

--- a/style.css
+++ b/style.css
@@ -155,16 +155,41 @@ section {
 /* === Utility Classes === */
 
 .header {
+  margin: 0;
+  min-height: 100vh;
+  padding: 4rem 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   text-align: center;
+  background: linear-gradient(180deg, rgba(231,140,140,0.15), var(--background));
+
+  .logo {
+    width: 220px;
+    margin-bottom: 1rem;
+  }
+
+  h1 {
+    margin: 0.5rem 0;
+  }
+
+  .strapline {
+    font-weight: 300;
+    font-size: var(--font-lg);
+    margin-bottom: 1rem;
+  }
+
+  .intro {
+    max-width: 600px;
+  }
 
   p {
     text-align: left;
   }
-  .strapline {
-    font-weight: 100;
-  }
-  .logo {
-    width: 260px;
+
+  .button {
+    margin-top: 1.5rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Transform header section into a full-screen hero with centered layout and soft gradient background
- Add call-to-action button linking to how-it-works section in both English and Portuguese pages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mamacircle/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6897aab3c53c832a9b8165add819ffb5