### PR TITLE
Refine layout spacing and contrast

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -62,23 +62,22 @@
       </nav>
     </div>
   </header>
+  <section class="header">
+    <img class="logo" src="assets/mandala-circle.png" alt="Logo Mama Circle - Mandala"/>
+    <h1>Mama Circle</h1>
+    <h2 class="strapline">um lugar gentil para pousar na maternidade</h2>
+
+    <div class="intro">
+        <p>Se você se tornou mãe recentemente e está se sentindo sobrecarregada, emocional, ou só precisando de uma palavra gentil, esse espaço é para você.</p>
+        <p>O Mama Circle não é um grupo nem um app. É um sinal silencioso, uma forma simples de mães se encontrarem através da hashtag <span class="hashtag">#mamacircle 💞</span>.</p>
+        <p>Talvez você encontre alguém que diga:<br />
+        <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span>, você pode contar comigo, se se sentir segura.</em><br />
+      <strong>E ela diz com intenção.</strong></p>
+    </div>
+    <a class="button" href="#how-it-works">Saiba como funciona</a>
+  </section>
 
   <main id="main" role="main" class="wrapper" tabindex="-1">
-    <section class="header">
-      <img class="logo" src="assets/mandala-circle.png" alt="Logo Mama Circle - Mandala"/>
-      <h1>Mama Circle</h1>
-      <h2 class="strapline">um lugar gentil para pousar na maternidade</h2>
-
-      <div class="intro">
-          <p>Se você se tornou mãe recentemente e está se sentindo sobrecarregada, emocional, ou só precisando de uma palavra gentil, esse espaço é para você.</p>
-          <p>O Mama Circle não é um grupo nem um app. É um sinal silencioso, uma forma simples de mães se encontrarem através da hashtag <span class="hashtag">#mamacircle 💞</span>.</p>
-          <p>Talvez você encontre alguém que diga:<br />
-          <em class="quote">Faço parte do <span class="hashtag">#mamacircle 💞</span>, você pode contar comigo, se se sentir segura.</em><br />
-        <strong>E ela diz com intenção.</strong></p>
-      </div>
-      <a class="button" href="#how-it-works">Saiba como funciona</a>
-    </section>
-
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">
       <h2 id="manifesto-heading">O Manifesto do Mama Circle</h2>
       <ul class="blockquote">

--- a/index.html
+++ b/index.html
@@ -62,23 +62,22 @@
       </nav>
     </div>
   </header>
+  <section class="header">
+    <img class="logo" src="assets/mandala-circle.png" alt="Mama Circle - Mandala Logo"/>
+    <h1>Mama Circle</h1>
+    <h2 class="strapline">A soft place to land in motherhood</h2>
+
+    <div class="intro">
+      <p>If you're a new mama feeling overwhelmed, emotional, or simply in need of a kind word, this space is for you.</p>
+      <p>Mama Circle is not a group or an app. It's a quiet signal, a simple way for mamas to find one another through <span class="hashtag">#mamacircle 💞</span>.</p>
+      <p>You might come across someone who says:<br />
+      <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</em><br />
+    <strong>And they’ll mean it.</strong></p>
+    </div>
+    <a class="button" href="#how-it-works">Learn how it works</a>
+  </section>
 
   <main id="main" role="main" class="wrapper" tabindex="-1">
-    <section class="header">
-      <img class="logo" src="assets/mandala-circle.png" alt="Mama Circle - Mandala Logo"/>
-      <h1>Mama Circle</h1>
-      <h2 class="strapline">A soft place to land in motherhood</h2>
-
-      <div class="intro">
-        <p>If you're a new mama feeling overwhelmed, emotional, or simply in need of a kind word, this space is for you.</p>
-        <p>Mama Circle is not a group or an app. It's a quiet signal, a simple way for mamas to find one another through <span class="hashtag">#mamacircle 💞</span>.</p>
-        <p>You might come across someone who says:<br />
-        <em class="quote">I’m part of <span class="hashtag">#mamacircle 💞</span>, you can always reach out to me (if it feels safe for you).</em><br />
-      <strong>And they’ll mean it.</strong></p>
-      </div>
-      <a class="button" href="#how-it-works">Learn how it works</a>
-    </section>
-
     <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">
       <h2 id="manifesto-heading">The Mama Circle Manifesto</h2>
         <ul class="blockquote">

--- a/style.css
+++ b/style.css
@@ -1,17 +1,17 @@
 :root {
-  --background: #fdfaf7;
-  --text: #1e1e1e;
-  --headline: #111;
-  --accent: #e78c8c;
+  --background: #ffffff;
+  --text: #111111;
+  --headline: #000000;
+  --accent: #d14d4d;
   --surface: #ffffff;
-  --surface-muted: #f3f1ee;
-  --border: #ddd;
+  --surface-muted: #eceae8;
+  --border: #bbbbbb;
 
-  --font-base: 1rem;
-  --font-scale: 1.333;
+  --font-base: 0.9rem;
+  --font-scale: 1.25;
 
-  --font-xs: 0.75rem;
-  --font-sm: 0.875rem;
+  --font-xs: 0.7rem;
+  --font-sm: 0.8rem;
   --font-md: var(--font-base);
   --font-lg: calc(var(--font-md) * var(--font-scale));
   --font-xl: calc(var(--font-lg) * var(--font-scale));
@@ -19,25 +19,26 @@
 }
 
 /* === Dark Mode === */
+
 [data-theme="dark"] {
-  --background: #1a1a1a;
-  --text: #fdfdfd;
+  --background: #121212;
+  --text: #ffffff;
   --headline: #ffffff;
-  --accent: #ff9ca5;
-  --surface: #262626;
-  --surface-muted: #333;
-  --border: #444;
+  --accent: #ff6f7f;
+  --surface: #1e1e1e;
+  --surface-muted: #2a2a2a;
+  --border: #555555;
 }
 
 /* === Modern Theme === */
 [data-theme="modern"] {
   --background: #ffffff;
-  --text: #222222;
+  --text: #111111;
   --headline: #0d0d0d;
-  --accent: #007bff;
+  --accent: #0056b3;
   --surface: #f5f5f5;
   --surface-muted: #e5e5e5;
-  --border: #cccccc;
+  --border: #999999;
 }
 
 [data-theme="modern"] h1,
@@ -146,10 +147,10 @@ ul {
 main {
   max-width: 760px;
   margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: clamp(1rem, 4vw, 2rem) 1rem;
 }
 section {
-  margin: 2rem 0;
+  margin: clamp(1.5rem, 5vw, 2rem) 0;
 }
 
 /* === Utility Classes === */
@@ -157,7 +158,7 @@ section {
 .header {
   margin: 0;
   min-height: 100vh;
-  padding: 4rem 1rem;
+  padding: clamp(2rem, 6vw, 4rem) 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -166,7 +167,7 @@ section {
   background: linear-gradient(180deg, rgba(231,140,140,0.15), var(--background));
 
   .logo {
-    width: 220px;
+    width: 150px;
     margin-bottom: 1rem;
   }
 
@@ -543,7 +544,7 @@ section {
 .footer-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 2rem;
+  gap: clamp(1rem, 4vw, 2rem);
   justify-content: space-between;
   max-width: 1000px;
   margin: 0 auto;
@@ -619,7 +620,7 @@ section {
   }
   .footer-grid {
     max-width: 1200px;
-    gap: 3rem;
+    gap: clamp(2rem, 3vw, 3rem);
   }
   .mama-card {
     flex: 0 0 300px;


### PR DESCRIPTION
## Summary
- shrink header logo and reduce base font sizes for a lighter look
- boost color contrast across default, dark, and modern themes
- introduce responsive spacing using `clamp` for sections and footer layout
- move hero header outside main for full-width layout on homepages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ad06f724832a88bfdd4980829e43