### PR TITLE
fix: reveal quote marks and smooth transitions

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const card = button.closest('.mama-card');
       card.classList.toggle('expanded', !expanded);
       button.setAttribute('aria-expanded', String(!expanded));
+      button.textContent = expanded ? 'Show more' : 'Show less';
     });
   });
 });

--- a/style.css
+++ b/style.css
@@ -471,10 +471,12 @@ section {
 .quote-wrapper {
   overflow: hidden;
   margin-top: 0.5rem;
-  max-height: 10.5em;
+  padding-top: 1rem;
+  max-height: calc(10.5em + 1rem);
+  transition: max-height 0.3s ease;
 }
 .mama-card.expanded .quote-wrapper {
-  max-height: 100em;
+  max-height: calc(100em + 1rem);
 }
 .show-more {
   font-size: var(--font-xs);
@@ -638,7 +640,6 @@ section {
     transform: translateY(-4px);
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
   }
-  .quote-wrapper { transition: max-height 0.3s ease; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- ensure quote pseudo-element isn't clipped by adding padding to wrapper
- apply max-height transition globally for smoother show/hide and toggle button label

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1dac413c832a900eaa6e133af1b9