### PR TITLE
Enable smooth scrolling and improve button contrast

### DIFF
--- a/script.js
+++ b/script.js
@@ -76,6 +76,24 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const navLinks = document.querySelectorAll('.site-nav a[href^="#"]');
+  navLinks.forEach((link) => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const targetId = link.getAttribute('href').substring(1);
+      const target = document.getElementById(targetId);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth' });
+      }
+      if (nav && nav.classList.contains('open')) {
+        nav.classList.remove('open');
+        if (toggleButton) {
+          toggleButton.setAttribute('aria-expanded', 'false');
+        }
+      }
+    });
+  });
+
   // Language highlighting
   const langLinks = document.querySelectorAll('.lang-link');
   const currentLang = document.documentElement.lang;

--- a/style.css
+++ b/style.css
@@ -51,6 +51,7 @@
 html {
   font-size: 100%;
   scroll-padding-top: 5rem;
+  scroll-behavior: smooth;
 }
 body {
   background: var(--background);
@@ -231,7 +232,7 @@ section {
 }
 .button:hover {
   background-color: var(--accent);
-  color: var(--text);
+  color: #fff;
 }
 .quote {
   font-style: italic;
@@ -627,7 +628,6 @@ section {
     
 /* === Motion Preferences === */
 @media (prefers-reduced-motion: no-preference) {
-  html { scroll-behavior: smooth; }
   a { transition: color 0.2s ease; }
   .language-switcher a { transition: opacity 0.2s ease; }
   .mama-card {


### PR DESCRIPTION
## Summary
- Add `scroll-behavior: smooth` for in-page navigation and JS to handle smooth scrolling on menu links.
- Ensure hover state of buttons uses white text for accessible contrast.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1e7081e4832aa89a3f76a080d1be