### PR TITLE
Hide show-more button when quotes are short

### DIFF
--- a/script.js
+++ b/script.js
@@ -111,6 +111,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const showMoreButtons = document.querySelectorAll('.show-more');
   showMoreButtons.forEach((button) => {
+    const wrapper = document.getElementById(button.getAttribute('aria-controls'));
+    const quote = wrapper ? wrapper.querySelector('.quote') : null;
+
+    if (quote && quote.offsetHeight < 165) {
+      button.style.display = 'none';
+    }
+
     button.addEventListener('click', () => {
       const expanded = button.getAttribute('aria-expanded') === 'true';
       const card = button.closest('.mama-card');

--- a/style.css
+++ b/style.css
@@ -472,7 +472,7 @@ section {
   overflow: hidden;
   margin-top: 0.5rem;
   padding-top: 1rem;
-  max-height: calc(10.5em + 1rem);
+  max-height: 165px;
   transition: max-height 0.3s ease;
 }
 .mama-card.expanded .quote-wrapper {


### PR DESCRIPTION
## Summary
- Hide "Show more" button for quotes under 165px tall
- Set quote wrapper collapse height to 165px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1ffe3ae4832a9a09486b4e487d88