### PR TITLE
Add mama quotes to Portuguese version with translation tag

### DIFF
--- a/index-pt.html
+++ b/index-pt.html
@@ -147,7 +147,23 @@
         <p>Essas mães compartilharam o que o <span class="hashtag">#mamacircle 💞</span> significa para elas. Talvez você se veja nessas histórias, ou tome coragem para se aproximar.</p>
 
       <div class="circle-list">
-        <!-- Cartões traduzidos podem ser adicionados aqui futuramente -->
+        <article class="mama-card">
+          <h3>Nati<span>, Perth, Escócia</span></h3>
+          <div class="quote-wrapper" id="quote-nati">
+            <p class="quote">Olá, mamas <3 Sou uma mãe orgulhosa de uma linda criança de 3 anos. Estar longe da família (no exterior) tem sido uma jornada difícil. Conciliar trabalho, vida de casal e criar uma criança... ufa! Não somos todas heroínas?</p>
+            <span class="translation-tag" data-source-lang="EN"></span>
+          </div>
+          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-nati">Ver mais</button>
+        </article>
+
+        <article class="mama-card">
+          <h3>Natalia<span>, Amsterdã, Países Baixos</span></h3>
+          <div class="quote-wrapper" id="quote-natalia">
+            <p class="quote">Às vezes não sabemos a quem fazer aquela pergunta “boba”, ou se é normal sentir o que estamos sentindo. Quando o primeiro bebê nasce, você também renasce, e fica perdida, insegura. Eu me senti completamente perdida. Espero poder passar adiante o apoio que recebi.</p>
+            <span class="translation-tag" data-source-lang="EN"></span>
+          </div>
+          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-natalia">Ver mais</button>
+        </article>
       </div>
 
       <div class="join-banner left-accent section-muted section-box" role="complementary">

--- a/script.js
+++ b/script.js
@@ -97,6 +97,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Language highlighting
   const langLinks = document.querySelectorAll('.lang-link');
   const currentLang = document.documentElement.lang;
+  const showMoreText =
+    currentLang === 'pt'
+      ? { more: 'Ver mais', less: 'Ver menos' }
+      : { more: 'Show more', less: 'Show less' };
 
   langLinks.forEach((link) => {
     const linkLang = link.getAttribute('lang');
@@ -116,6 +120,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (quote && quote.offsetHeight < 165) {
       button.style.display = 'none';
+    } else {
+      button.textContent = showMoreText.more;
     }
 
     button.addEventListener('click', () => {
@@ -123,7 +129,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const card = button.closest('.mama-card');
       card.classList.toggle('expanded', !expanded);
       button.setAttribute('aria-expanded', String(!expanded));
-      button.textContent = expanded ? 'Show more' : 'Show less';
+      button.textContent = expanded ? showMoreText.more : showMoreText.less;
     });
   });
+
+  const translationTags = document.querySelectorAll('.translation-tag');
+  if (translationTags.length) {
+    const translationPrefix =
+      currentLang === 'pt' ? 'traduzido do' : 'translated from';
+    translationTags.forEach((tag) => {
+      const source = (tag.dataset.sourceLang || 'EN').toUpperCase();
+      tag.textContent = `(${translationPrefix} ${source})`;
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -407,6 +407,16 @@ section {
   color: #555;
 }
 
+.translation-tag {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: var(--font-xs);
+  background: var(--surface-muted);
+  color: #555;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
 /* === Tabs === */
 .tabs {
   display: flex;


### PR DESCRIPTION
## Summary
- add translated “mamas words” section to Portuguese home page with a note for translated quotes
- style translation note tag
- internationalize show-more button text based on page language
- localize translation note text so it matches the page language

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b225e7810832abd2d829c1a112527