### PR TITLE
Reduce spacing between nav and hero header

### DIFF
--- a/script.js
+++ b/script.js
@@ -132,6 +132,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
+  document.querySelectorAll('a[href*=".html"]:not(.lang-link)').forEach((link) => {
+    const url = new URL(link.href, window.location.origin);
+    if (theme) {
+      url.searchParams.set('theme', theme);
+    }
+    url.searchParams.set('lang', lang);
+    link.href = url.toString();
+  });
+
   const showMoreButtons = document.querySelectorAll('.show-more');
   showMoreButtons.forEach((button) => {
     const wrapper = document.getElementById(button.getAttribute('aria-controls'));

--- a/style.css
+++ b/style.css
@@ -159,7 +159,7 @@ section {
 .header {
   margin: 0;
   min-height: 100vh;
-  padding: clamp(1rem, 4vw, 2rem) 1rem;
+  padding: clamp(0.5rem, 2vw, 1rem) 1rem clamp(1rem, 4vw, 2rem);
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Summary
- tighten header hero padding to bring it closer to the navigation bar
- keep selected language when navigating to Code of Care or other internal pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8524f370832aa8b4526e0a265345