### PR TITLE
Combine manifesto with how-it-works tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,23 @@
   </section>
 
   <main id="main" role="main" class="wrapper" tabindex="-1">
-    <section id="manifesto" class="left-accent section-box" aria-labelledby="manifesto-heading">
-      <h2 id="manifesto-heading" data-i18n="manifesto_heading"></h2>
+    <section id="how-it-works">
+      <h2 data-i18n="how_heading"></h2>
+
+      <div class="tabs" role="tablist" aria-label="Mama Circle content">
+        <button class="tab active" data-tab="manifesto" role="tab" aria-selected="true" aria-controls="manifesto" id="tab-manifesto">
+          <i class="fa-solid fa-scroll" aria-hidden="true"></i> <span data-i18n="tab_manifesto"></span>
+        </button>
+        <button class="tab" data-tab="new-mamas" role="tab" aria-selected="false" aria-controls="new-mamas" id="tab-new">
+          <i class="fa-solid fa-baby" aria-hidden="true"></i> <span data-i18n="tab_new"></span>
+        </button>
+        <button class="tab" data-tab="supporters" role="tab" aria-selected="false" aria-controls="supporters" id="tab-supporters">
+          <i class="fa-solid fa-hand-holding-heart" aria-hidden="true"></i> <span data-i18n="tab_supporters"></span>
+        </button>
+      </div>
+
+      <div class="tab-content left-accent section-box active" id="manifesto" role="tabpanel" aria-labelledby="tab-manifesto">
+        <h3 data-i18n="manifesto_heading"></h3>
         <ul class="blockquote">
           <li data-i18n="manifesto_li1"></li>
           <li data-i18n="manifesto_li2"></li>
@@ -101,21 +116,9 @@
         </ul>
 
         <p class="note" data-i18n="values_note"></p>
-    </section>
-
-    <section id="how-it-works">
-      <h2 data-i18n="how_heading"></h2>
-
-      <div class="tabs" role="tablist" aria-label="Mama Circle roles">
-        <button class="tab active" data-tab="new-mamas" role="tab" aria-selected="true" aria-controls="new-mamas" id="tab-new">
-          <i class="fa-solid fa-baby" aria-hidden="true"></i> <span data-i18n="tab_new"></span>
-        </button>
-        <button class="tab" data-tab="supporters" role="tab" aria-selected="false" aria-controls="supporters" id="tab-supporters">
-          <i class="fa-solid fa-hand-holding-heart" aria-hidden="true"></i> <span data-i18n="tab_supporters"></span>
-        </button>
       </div>
 
-      <div class="tab-content section-box highlighted active" id="new-mamas" role="tabpanel" aria-labelledby="tab-new">
+      <div class="tab-content section-box highlighted" id="new-mamas" role="tabpanel" aria-labelledby="tab-new" hidden>
         <h3 data-i18n="new_mamas_heading"></h3>
         <p data-i18n="new_mamas_p1"></p>
         <p data-i18n="new_mamas_quote"></p>
@@ -139,7 +142,7 @@
         </ul>
       </div>
 
-        <p class="note" data-i18n="how_note"></p>
+      <p class="note" data-i18n="how_note"></p>
     </section>
 
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,7 @@
   "how_heading": "How Mama Circle Works",
   "tab_new": "For New Mamas",
   "tab_supporters": "For Supporters",
+  "tab_manifesto": "Manifesto",
   "new_mamas_heading": "You're not alone.",
   "new_mamas_p1": "You might be here because someone shared this link, or you saw <span class=\"hashtag\">#mamacircle 💞</span> in someone's bio or message. That person is letting you know:",
   "new_mamas_quote": "<em class=\"quote\">You can always reach out to me (if it feels safe for you).</em>",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -25,6 +25,7 @@
   "how_heading": "Como o Mama Circle funciona",
   "tab_new": "Para novas mães",
   "tab_supporters": "Para apoiadoras",
+  "tab_manifesto": "Manifesto",
   "new_mamas_heading": "Você não está sozinha.",
   "new_mamas_p1": "Talvez você tenha chegado aqui por um link compartilhado ou viu <span class=\"hashtag\">#mamacircle 💞</span> na bio de alguém. Essa pessoa está dizendo:",
   "new_mamas_quote": "<em class=\"quote\">você pode contar comigo, se se sentir segura.</em>",

--- a/script.js
+++ b/script.js
@@ -103,6 +103,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       const targetId = link.getAttribute('href').substring(1);
       const target = document.getElementById(targetId);
       if (target) {
+        const tabButton = document.querySelector(`.tab[data-tab="${targetId}"]`);
+        if (tabButton) {
+          tabButton.click();
+        }
         target.scrollIntoView({ behavior: 'smooth' });
       }
       if (nav && nav.classList.contains('open')) {


### PR DESCRIPTION
## Summary
- Merge manifesto, new mamas, and supporter content into a single tabbed "How it works" section with manifesto first.
- Ensure navigation links open the correct tab content.
- Add translations for the new manifesto tab in English and Portuguese.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4367bc038832ab660556ddae92e1c