### PR TITLE
Fix nested media query in stylesheet

### DIFF
--- a/style.css
+++ b/style.css
@@ -639,8 +639,9 @@ section {
   }
   .mama-card {
     flex: 0 0 300px;
+  }
+}
 
-    
 /* === Motion Preferences === */
 @media (prefers-reduced-motion: no-preference) {
   a { transition: color 0.2s ease; }


### PR DESCRIPTION
## Summary
- close `.mama-card` rule and surrounding `@media (min-width: 1024px)` block so motion preference media queries are top-level

## Testing
- ⚠️ `npx --yes stylelint style.css` (403 Forbidden from npm registry)
- ✅ `python - <<'PY' ...` (script verifies `@media (prefers-reduced-motion)` at root level)


------
https://chatgpt.com/codex/tasks/task_e_68a444c001ac832aa9b7e08955fc691b