### PR TITLE
Add fade-in scroll animations respecting reduced motion

### DIFF
--- a/script.js
+++ b/script.js
@@ -173,5 +173,23 @@ document.addEventListener('DOMContentLoaded', async () => {
       tag.textContent = `(${translationPrefix} ${source})`;
     });
   }
+
+  const fadeEls = document.querySelectorAll('.section-box, .mama-card');
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (prefersReduced) {
+    fadeEls.forEach((el) => el.classList.add('fade-in'));
+  } else {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('fade-in');
+          obs.unobserve(entry.target);
+        }
+      });
+    });
+
+    fadeEls.forEach((el) => observer.observe(el));
+  }
 });
 

--- a/style.css
+++ b/style.css
@@ -209,6 +209,8 @@ section {
   padding: 2rem;
   border: 1px solid var(--border);
   border-radius: 6px;
+  opacity: 0;
+  transform: translateY(20px);
 
   &.highlighted {
     border-color: var(--accent);
@@ -468,6 +470,8 @@ section {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
+  opacity: 0;
+  transform: translateY(20px);
   padding: 1rem;
   font-size: var(--font-sm);
   display: flex;
@@ -639,8 +643,25 @@ section {
   }
   .mama-card {
     flex: 0 0 300px;
+  }
+}
 
-    
+/* === Animations === */
+.fade-in {
+  animation: fadeInUp 0.6s ease-out forwards;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* === Motion Preferences === */
 @media (prefers-reduced-motion: no-preference) {
   a { transition: color 0.2s ease; }
@@ -663,6 +684,14 @@ section {
   .mama-card:hover {
     transform: none;
     box-shadow: none;
+  }
+  .section-box,
+  .mama-card {
+    opacity: 1;
+    transform: none;
+  }
+  .fade-in {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add fade-in animation styles and keyframes with reduced-motion safeguards
- Observe `.section-box` and `.mama-card` elements and apply fade-in when scrolled into view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a444cde2e4832a80851353a9debdc0