### PR TITLE
feat: add carousel for mama cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,30 +150,34 @@
       <h2 data-i18n="circle_heading"></h2>
       <p data-i18n="circle_intro"></p>
 
-      <div class="circle-list">
-        <article class="mama-card">
-          <h3>Nati<span>, Perth, Scotland</span></h3>
-          <div class="quote-wrapper" id="quote-nati">
-            <p class="quote" data-i18n="card1_quote"></p>
-          </div>
-          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-nati" data-i18n="show_more"></button>
-        </article>
+      <div class="circle-carousel">
+        <button class="carousel-control prev" aria-label="Previous">&#10094;</button>
+        <div class="carousel-track">
+          <article class="mama-card">
+            <h3>Nati<span>, Perth, Scotland</span></h3>
+            <div class="quote-wrapper" id="quote-nati">
+              <p class="quote" data-i18n="card1_quote"></p>
+            </div>
+            <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-nati" data-i18n="show_more"></button>
+          </article>
 
-        <article class="mama-card">
-          <h3>Natalia<span>, Amsterdam, Netherlands</span></h3>
-          <div class="quote-wrapper" id="quote-natalia">
-            <p class="quote" data-i18n="card2_quote"></p>
-          </div>
-          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-natalia" data-i18n="show_more"></button>
-        </article>
+          <article class="mama-card">
+            <h3>Natalia<span>, Amsterdam, Netherlands</span></h3>
+            <div class="quote-wrapper" id="quote-natalia">
+              <p class="quote" data-i18n="card2_quote"></p>
+            </div>
+            <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-natalia" data-i18n="show_more"></button>
+          </article>
 
-        <article class="mama-card">
-          <h3>Ana<span>, Lisbon, Portugal</span></h3>
-          <div class="quote-wrapper" id="quote-ana">
-            <p class="quote" data-i18n="card3_quote"></p>
-          </div>
-          <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-ana" data-i18n="show_more"></button>
-        </article>
+          <article class="mama-card">
+            <h3>Ana<span>, Lisbon, Portugal</span></h3>
+            <div class="quote-wrapper" id="quote-ana">
+              <p class="quote" data-i18n="card3_quote"></p>
+            </div>
+            <button class="show-more" type="button" aria-expanded="false" aria-controls="quote-ana" data-i18n="show_more"></button>
+          </article>
+        </div>
+        <button class="carousel-control next" aria-label="Next">&#10095;</button>
       </div>
 
       <div class="join-banner left-accent section-muted section-box" role="complementary">

--- a/script.js
+++ b/script.js
@@ -165,6 +165,61 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   });
 
+  const carousel = document.querySelector('.circle-carousel');
+  if (carousel) {
+    const track = carousel.querySelector('.carousel-track');
+    const cards = track.querySelectorAll('.mama-card');
+    const prevBtn = carousel.querySelector('.carousel-control.prev');
+    const nextBtn = carousel.querySelector('.carousel-control.next');
+    let index = 0;
+    const intervalTime = 5000;
+    let autoPlay = setInterval(next, intervalTime);
+
+    function update() {
+      track.style.transform = `translateX(-${index * 100}%)`;
+    }
+
+    function next() {
+      index = (index + 1) % cards.length;
+      update();
+    }
+
+    function prev() {
+      index = (index - 1 + cards.length) % cards.length;
+      update();
+    }
+
+    function reset() {
+      pause();
+      autoPlay = setInterval(next, intervalTime);
+    }
+
+    function pause() {
+      clearInterval(autoPlay);
+      autoPlay = null;
+    }
+
+    function resume() {
+      if (!autoPlay) {
+        autoPlay = setInterval(next, intervalTime);
+      }
+    }
+
+    nextBtn.addEventListener('click', () => {
+      next();
+      reset();
+    });
+    prevBtn.addEventListener('click', () => {
+      prev();
+      reset();
+    });
+
+    carousel.addEventListener('mouseenter', pause);
+    carousel.addEventListener('mouseleave', resume);
+    carousel.addEventListener('focusin', pause);
+    carousel.addEventListener('focusout', resume);
+  }
+
   const translationTags = document.querySelectorAll('.translation-tag');
   if (translationTags.length) {
     const translationPrefix = t('translation_from') || (currentLang === 'pt' ? 'traduzido do' : 'translated from');

--- a/style.css
+++ b/style.css
@@ -455,16 +455,20 @@ section {
 
 /* === Mama Cards === */
 .wall { margin-top: 4rem; }
-.circle-list {
+.circle-carousel {
+  position: relative;
+  overflow: hidden;
+}
+.carousel-track {
   display: flex;
-  gap: 1rem;
-  overflow-x: auto;
-  overflow-y: visible !important;
-  padding-bottom: 1rem;
-  scroll-snap-type: x mandatory;
+  transition: transform 0.5s ease;
+}
+.carousel-track .mama-card {
+  flex: 0 0 100%;
 }
 .mama-card {
-  flex: 0 0 250px;
+  max-width: 250px;
+  margin: 0 auto;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -481,6 +485,23 @@ section {
     color: #777;
   }
 }
+.carousel-control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text);
+}
+.carousel-control.prev { left: 0.5rem; }
+.carousel-control.next { right: 0.5rem; }
 .quote-wrapper {
   overflow: hidden;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- replace flex-based list with carousel wrapper for mama cards
- auto-scroll cards with pause on interaction
- style navigation controls for manual cycling

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a444d3b2bc832abd3391609df9ef77