### PR TITLE
Fix carousel card width for proper rotation

### DIFF
--- a/script.js
+++ b/script.js
@@ -176,7 +176,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     let autoPlay = setInterval(next, intervalTime);
 
     function update() {
-      track.style.transform = `translateX(-${index * 100}%)`;
+      const gap = parseFloat(getComputedStyle(track).gap) || 0;
+      const cardWidth = cards[0].offsetWidth + gap;
+      track.style.transform = `translateX(-${index * cardWidth}px)`;
     }
 
     function next() {

--- a/style.css
+++ b/style.css
@@ -460,6 +460,7 @@ section {
 .circle-carousel {
   position: relative;
   overflow: hidden;
+  padding: 0 1rem;
 }
 .carousel-track {
   display: flex;
@@ -467,6 +468,7 @@ section {
 }
 .carousel-track .mama-card {
   flex: 0 0 100%;
+  max-width: none;
 }
 .mama-card {
   max-width: 250px;


### PR DESCRIPTION
## Summary
- Allow carousel cards to fill the track and add side padding for visual spacing
- Slide track by card width to rotate between cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f5d065c832ab4094d02c0f2faf6